### PR TITLE
fix minor portability problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project(DC)
 
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-
-	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
-		set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -lc++")
-	else()
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-	endif()
-
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror -Wno-nested-anon-types")
-
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I '/opt/local/include/eigen2'")
 endif()
 
 #SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
@@ -30,11 +19,13 @@ add_executable(dc
 	src/vol/Contouring.cpp
 )
 
-add_executable(test
+add_executable(tests
 	src/test.cpp
 	src/math/Math.cpp
 	src/math/Solver.cpp
 	src/vol/Contouring.cpp
 )
 
-add_test(core test)
+add_test(core tests)
+
+set_property(TARGET dc tests PROPERTY CXX_STANDARD 11)

--- a/src/math/Math.cpp
+++ b/src/math/Math.cpp
@@ -38,7 +38,7 @@ namespace math
 	
 	float nextFloat(float arg)
 	{
-		if (isnan(arg)) return arg;
+		if (std::isnan(arg)) return arg;
 		if (arg==+INF)  return +INF; // Can't go higher.
 		if (arg==0)     return std::numeric_limits<float>::denorm_min();
 		

--- a/src/util/Array3D.hpp
+++ b/src/util/Array3D.hpp
@@ -3,6 +3,7 @@
 
 #include <math/Vec3.hpp>
 #include <algorithm> // fill_n
+#include <memory>
 
 
 namespace util


### PR DESCRIPTION
Fix the project so that it compiles on my machine (Ubuntu 16.04).
Simplify the CMakeLists file to remove platform- and compiler-
dependent code. Just use the C++11 standard on all compilers.
Rename 'test' to 'tests' to eliminate a cmake warning.