### PR TITLE
Fix compile errors with clang++ on Linux

### DIFF
--- a/src/math/Math.cpp
+++ b/src/math/Math.cpp
@@ -5,6 +5,7 @@
 //  Created by emilk on 2012-10-15.
 
 #include "Math.hpp"
+#include <cmath>
 #include <cassert>
 
 
@@ -38,7 +39,7 @@ namespace math
 	
 	float nextFloat(float arg)
 	{
-		if (isnan(arg)) return arg;
+		if (std::isnan(arg)) return arg;
 		if (arg==+INF)  return +INF; // Can't go higher.
 		if (arg==0)     return std::numeric_limits<float>::denorm_min();
 		

--- a/src/math/Math.hpp
+++ b/src/math/Math.hpp
@@ -7,6 +7,7 @@
 #ifndef EmiLib_Math_hpp
 #define EmiLib_Math_hpp
 
+#include <cstdint>
 #include <cmath>
 #include <limits>
 #include <algorithm>

--- a/src/util/Array3D.hpp
+++ b/src/util/Array3D.hpp
@@ -1,6 +1,7 @@
 #ifndef UTIL_ARRAY_3D_HPP
 #define UTIL_ARRAY_3D_HPP
 
+#include <memory>
 #include <math/Vec3.hpp>
 #include <algorithm> // fill_n
 


### PR DESCRIPTION
Building with GCC fails, but setting CC and CXX to clang/clang++ fixes
the build for me w/o changes to cmake config.

Mostly this is adding missing headers.